### PR TITLE
Thrift instrumentation simplifications

### DIFF
--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncClientInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncClientInstrumentation.java
@@ -96,7 +96,6 @@ class ThriftAsyncClientInstrumentation implements TypeInstrumentation {
       if (args[args.length - 1] != null) {
         AsyncMethodCallback<?> callback = (AsyncMethodCallback<?>) args[args.length - 1];
         args[args.length - 1] = AsyncMethodCallbackUtil.wrap(callback, clientContext);
-        clientContext.setHasAsyncCallback();
       }
       return new Object[] {args, clientContext};
     }

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncClientInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncClientInstrumentation.java
@@ -70,14 +70,9 @@ class ThriftAsyncClientInstrumentation implements TypeInstrumentation {
         @Advice.Origin("#t") Class<?> declaringClass,
         @Advice.Argument(0) TProtocolFactory protocolFactory,
         @Advice.Argument(2) TNonblockingTransport transport) {
-      Class<?> serviceClass = declaringClass;
-      if (serviceClass.getDeclaringClass() != null) {
-        serviceClass = serviceClass.getDeclaringClass();
-      }
-
       return new ClientProtocolDecorator.Factory(
           protocolFactory,
-          serviceClass.getName(),
+          ThriftSingletons.thriftServiceName(declaringClass),
           ThriftSingletons.clientInstrumenter(),
           getPropagators(),
           transport);

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftServiceClientInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftServiceClientInstrumentation.java
@@ -48,13 +48,11 @@ class ThriftServiceClientInstrumentation implements TypeInstrumentation {
         @Advice.This TServiceClient serviceClient,
         @Advice.FieldValue("iprot_") TProtocol inProtocol,
         @Advice.FieldValue("oprot_") TProtocol outProtocol) {
-      Class<?> serviceClass = serviceClient.getClass();
-      if (serviceClass.getDeclaringClass() != null) {
-        serviceClass = serviceClass.getDeclaringClass();
-      }
       ClientProtocolDecorator.AgentDecorator agentDecorator =
           new ClientProtocolDecorator.AgentDecorator(
-              serviceClass.getName(), ThriftSingletons.clientInstrumenter(), getPropagators());
+              ThriftSingletons.thriftServiceName(serviceClient.getClass()),
+              ThriftSingletons.clientInstrumenter(),
+              getPropagators());
       return new Object[] {
         agentDecorator.decorate(inProtocol), agentDecorator.decorate(outProtocol)
       };

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftSingletons.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftSingletons.java
@@ -36,5 +36,15 @@ public final class ThriftSingletons {
     return GlobalOpenTelemetry.get().getPropagators();
   }
 
+  /**
+   * Returns the enclosing thrift service class name (e.g. {@code com.example.MyService}) for an
+   * inner client class such as {@code com.example.MyService$Client}; falls back to the class itself
+   * when there is no enclosing class.
+   */
+  public static String thriftServiceName(Class<?> clientClass) {
+    Class<?> declaring = clientClass.getDeclaringClass();
+    return declaring != null ? declaring.getName() : clientClass.getName();
+  }
+
   private ThriftSingletons() {}
 }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/ThriftTelemetry.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/ThriftTelemetry.java
@@ -89,7 +89,6 @@ public final class ThriftTelemetry {
                 if (args.length > 0 && args[args.length - 1] instanceof AsyncMethodCallback) {
                   AsyncMethodCallback<?> callback = (AsyncMethodCallback<?>) args[args.length - 1];
                   args[args.length - 1] = AsyncMethodCallbackUtil.wrap(callback, clientContext);
-                  clientContext.setHasAsyncCallback();
                 }
                 return method.invoke(client, args);
               } catch (InvocationTargetException e) {

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/ThriftTelemetry.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/ThriftTelemetry.java
@@ -93,7 +93,7 @@ public final class ThriftTelemetry {
                 return method.invoke(client, args);
               } catch (InvocationTargetException e) {
                 error = e.getCause();
-                throw e.getCause();
+                throw error;
               } catch (Throwable t) {
                 error = t;
                 throw t;

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/AsyncMethodCallbackUtil.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/AsyncMethodCallbackUtil.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.thrift.v0_13.internal;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import javax.annotation.Nullable;
 import org.apache.thrift.async.AsyncMethodCallback;
 
 /**
@@ -16,13 +15,8 @@ import org.apache.thrift.async.AsyncMethodCallback;
  */
 public final class AsyncMethodCallbackUtil {
 
-  @Nullable
   public static <T> AsyncMethodCallback<T> wrap(
-      @Nullable AsyncMethodCallback<T> callback, ClientCallContext clientCallContext) {
-    if (callback == null) {
-      return null;
-    }
-
+      AsyncMethodCallback<T> callback, ClientCallContext clientCallContext) {
     Context context = Context.current();
     return new AsyncMethodCallback<T>() {
 

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientCallContext.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientCallContext.java
@@ -15,7 +15,6 @@ public final class ClientCallContext {
   private static final ThreadLocal<ClientCallContext> current = new ThreadLocal<>();
 
   @Nullable private ClientProtocolDecorator protocolDecorator;
-  private boolean hasAsyncCallback;
 
   public static ClientCallContext start() {
     ClientCallContext context = new ClientCallContext();
@@ -28,17 +27,6 @@ public final class ClientCallContext {
     if (context != null) {
       context.protocolDecorator = protocolDecorator;
     }
-  }
-
-  /** Returns {@code true} when a callback has been installed for ending the span. */
-  static boolean hasAsyncCallback() {
-    ClientCallContext context = current.get();
-    return context != null && context.hasAsyncCallback;
-  }
-
-  /** Notify that a callback has been installed for ending the span. */
-  public void setHasAsyncCallback() {
-    this.hasAsyncCallback = true;
   }
 
   public void endSpan(@Nullable Throwable throwable) {

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
@@ -206,6 +206,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
     private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
     private final ContextPropagators propagators;
     @Nullable private final TTransport configuredTransport;
+    private final State state = new State();
 
     public Factory(
         TProtocolFactory protocolFactory,
@@ -229,7 +230,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
               instrumenter,
               propagators,
               configuredTransport,
-              new State(),
+              state,
               false);
       // span will be ended by the wrapped async callback, which calls back into this decorator
       ClientCallContext.setClientProtocolDecorator(decorator);

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
@@ -42,7 +42,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
       String serviceName,
       Instrumenter<ThriftRequest, ThriftResponse> instrumenter,
       ContextPropagators propagators) {
-    this(protocol, serviceName, instrumenter, propagators, null, new State());
+    this(protocol, serviceName, instrumenter, propagators, null, new State(), true);
   }
 
   private ClientProtocolDecorator(
@@ -51,7 +51,8 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
       Instrumenter<ThriftRequest, ThriftResponse> instrumenter,
       ContextPropagators propagators,
       @Nullable TTransport transport,
-      State state) {
+      State state,
+      boolean endSpanInline) {
     super(protocol);
     this.protocol = protocol;
     this.serviceName = serviceName;
@@ -59,9 +60,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
     this.propagators = propagators;
     this.transport = transport;
     this.state = state;
-    // if there's an async callback, the span will be ended in the callback
-    this.endSpan = !ClientCallContext.hasAsyncCallback();
-    ClientCallContext.setClientProtocolDecorator(this);
+    this.endSpan = endSpanInline;
   }
 
   @Override
@@ -226,13 +225,18 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
 
     @Override
     public TProtocol getProtocol(TTransport transport) {
-      return new ClientProtocolDecorator(
-          protocolFactory.getProtocol(transport),
-          serviceName,
-          instrumenter,
-          propagators,
-          configuredTransport,
-          state);
+      ClientProtocolDecorator decorator =
+          new ClientProtocolDecorator(
+              protocolFactory.getProtocol(transport),
+              serviceName,
+              instrumenter,
+              propagators,
+              configuredTransport,
+              state,
+              false);
+      // span will be ended by the wrapped async callback, which calls back into this decorator
+      ClientCallContext.setClientProtocolDecorator(decorator);
+      return decorator;
     }
   }
 
@@ -260,7 +264,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
         return protocol;
       }
       return new ClientProtocolDecorator(
-          protocol, serviceName, instrumenter, propagators, null, state);
+          protocol, serviceName, instrumenter, propagators, null, state, true);
     }
   }
 }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
@@ -29,6 +29,7 @@ import org.apache.thrift.transport.TTransportException;
  */
 public final class ClientProtocolDecorator extends TProtocolDecorator {
 
+  private final TProtocol protocol;
   private final String serviceName;
   private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
   private final ContextPropagators propagators;
@@ -53,6 +54,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
       State state,
       boolean endSpanInline) {
     super(protocol);
+    this.protocol = protocol;
     this.serviceName = serviceName;
     this.instrumenter = instrumenter;
     this.propagators = propagators;
@@ -128,7 +130,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
                   carrier.put(key, value);
                 }
               });
-      ContextPropagationUtil.writeHeaders(this, headers);
+      ContextPropagationUtil.writeHeaders(protocol, headers);
       state.contextPropagated = true;
     }
 

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
@@ -29,7 +29,6 @@ import org.apache.thrift.transport.TTransportException;
  */
 public final class ClientProtocolDecorator extends TProtocolDecorator {
 
-  private final TProtocol protocol;
   private final String serviceName;
   private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
   private final ContextPropagators propagators;
@@ -54,7 +53,6 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
       State state,
       boolean endSpanInline) {
     super(protocol);
-    this.protocol = protocol;
     this.serviceName = serviceName;
     this.instrumenter = instrumenter;
     this.propagators = propagators;
@@ -130,7 +128,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
                   carrier.put(key, value);
                 }
               });
-      ContextPropagationUtil.writeHeaders(protocol, headers);
+      ContextPropagationUtil.writeHeaders(this, headers);
       state.contextPropagated = true;
     }
 

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ClientProtocolDecorator.java
@@ -208,7 +208,6 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
     private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
     private final ContextPropagators propagators;
     @Nullable private final TTransport configuredTransport;
-    private final State state = new State();
 
     public Factory(
         TProtocolFactory protocolFactory,
@@ -232,7 +231,7 @@ public final class ClientProtocolDecorator extends TProtocolDecorator {
               instrumenter,
               propagators,
               configuredTransport,
-              state,
+              new State(),
               false);
       // span will be ended by the wrapped async callback, which calls back into this decorator
       ClientCallContext.setClientProtocolDecorator(decorator);

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
@@ -28,7 +28,6 @@ import org.apache.thrift.protocol.TType;
  */
 public final class ServerInProtocolDecorator extends TProtocolDecorator {
 
-  private final TProtocol protocol;
   private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
   private final String serviceName;
 
@@ -42,7 +41,6 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
       String serviceName,
       Instrumenter<ThriftRequest, ThriftResponse> instrumenter) {
     super(protocol);
-    this.protocol = protocol;
     this.serviceName = serviceName;
     this.instrumenter = instrumenter;
   }
@@ -60,7 +58,7 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
     // start span when context propagation field is read, if the message doesn't include context
     // propagation field, span will be started in readMessageEnd()
     if (field.id == ContextPropagationUtil.TRACE_CONTEXT_FIELD_ID && field.type == TType.MAP) {
-      Map<String, String> headers = ContextPropagationUtil.readHeaders(protocol);
+      Map<String, String> headers = ContextPropagationUtil.readHeaders(this);
       super.readFieldEnd();
 
       Socket socket = SocketAccessor.getSocket(super.getTransport());

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
@@ -28,6 +28,7 @@ import org.apache.thrift.protocol.TType;
  */
 public final class ServerInProtocolDecorator extends TProtocolDecorator {
 
+  private final TProtocol protocol;
   private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
   private final String serviceName;
 
@@ -41,6 +42,7 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
       String serviceName,
       Instrumenter<ThriftRequest, ThriftResponse> instrumenter) {
     super(protocol);
+    this.protocol = protocol;
     this.serviceName = serviceName;
     this.instrumenter = instrumenter;
   }
@@ -58,7 +60,7 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
     // start span when context propagation field is read, if the message doesn't include context
     // propagation field, span will be started in readMessageEnd()
     if (field.id == ContextPropagationUtil.TRACE_CONTEXT_FIELD_ID && field.type == TType.MAP) {
-      Map<String, String> headers = ContextPropagationUtil.readHeaders(this);
+      Map<String, String> headers = ContextPropagationUtil.readHeaders(protocol);
       super.readFieldEnd();
 
       Socket socket = SocketAccessor.getSocket(super.getTransport());

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ThriftRpcAttributesGetter.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ThriftRpcAttributesGetter.java
@@ -48,7 +48,7 @@ final class ThriftRpcAttributesGetter
       ThriftRequest request, @Nullable ThriftResponse response, @Nullable Throwable error) {
     if (error instanceof TTransportException) {
       int errorCode = ((TTransportException) error).getType();
-      switch (((TTransportException) error).getType()) {
+      switch (errorCode) {
         case 0:
           return "UNKNOWN";
         case 1:


### PR DESCRIPTION
Simplifications for review on top of #18405. Each commit is a separate refactor:

- Drop `ThriftRequestAccess` / `ThriftResponseAccess` indirection — expose `ThriftRequest` constructors and `ThriftResponse.FAILED` directly.
- Remove ThreadLocal-based `endSpan` flag and circular construction-vs-registration order in `ClientProtocolDecorator` / `ClientCallContext`.
- Allocate a fresh `State` per `ClientProtocolDecorator.Factory.getProtocol(...)` call (was shared, concurrency bug for async).
- Drop duplicate `protocol` field in `ClientProtocolDecorator` and `ServerInProtocolDecorator`.
- `ThriftRpcAttributesGetter.getErrorType`: switch on the cached `errorCode` instead of calling `getType()` twice.
- `AsyncMethodCallbackUtil.wrap`: drop dead `@Nullable` + null-check (callers null-check first).
- `ThriftTelemetry.wrapAsyncClient`: keep separate `InvocationTargetException` and `Throwable` catches but call `getCause()` once.
- Extract `ThriftSingletons.thriftServiceName(Class<?>)` to dedupe the `getDeclaringClass()` unwrap in both javaagent ConstructorAdvices.